### PR TITLE
Fix bug in example

### DIFF
--- a/Example/AHDownloadButton/DownloadViewController.swift
+++ b/Example/AHDownloadButton/DownloadViewController.swift
@@ -68,6 +68,7 @@ extension DownloadViewController: AHDownloadButtonDelegate {
         case .pending:
             break
         case .downloading, .downloaded:
+            downloadTimer?.invalidate()
             downloadButton.progress = 0
             downloadButton.state = .startDownload
         }


### PR DESCRIPTION
This fixes a bug in the example that caused the button to switch to state "downloaded" after the simulated download time even if the download has been cancelled.