### PR TITLE
Fixed button title width bug

### DIFF
--- a/AHDownloadButton/Classes/AHDownloadButton.swift
+++ b/AHDownloadButton/Classes/AHDownloadButton.swift
@@ -49,6 +49,7 @@ public final class AHDownloadButton: UIView {
     public var startDownloadButtonTitle: String = "GET" {
         didSet {
             startDownloadButton.setTitle(startDownloadButtonTitle, for: .normal)
+            startDownloadButtonTitleWidth = 0
         }
     }
     
@@ -153,6 +154,7 @@ public final class AHDownloadButton: UIView {
     public var downloadedButtonTitle: String = "OPEN" {
         didSet {
             downloadedButton.setTitle(downloadedButtonTitle, for: .normal)
+            downloadedButtonTitleWidth = 0
         }
     }
     


### PR DESCRIPTION
Was running into a bug where changing the button title string after the initial layout would cause the button width to not recalculate, and either be too wide or too skinny. This happened most often in reusable table view cells that would redraw for different content, in my use-case the button could say "INSTALL" "DOWNLOAD" or "UPDATE" which require 3 different widths, and scrolling on the list it would get out of sync almost immediately.

Setting the title width back to zero on string didSet causes the width constant to be recalculated on the next layout cycle, which fixes the problem.