### PR TITLE
Set Deployment Target to iOS 10 in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "AHDownloadButton",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v10)
     ],
     products: [
         .library(


### PR DESCRIPTION
https://github.com/amerhukic/AHDownloadButton/commit/6b78bee9c2959f1634870292e459c4ab0f911ba1 set deployment target to iOS 10, but in Package.swift it's still iOS 8. This PR fixed it.